### PR TITLE
fix: documentos_timbrados ya no incluye filas de fechas de otra tabla

### DIFF
--- a/consulta.py
+++ b/consulta.py
@@ -44,8 +44,16 @@ class Consulta:
         # Initialize a list to store the extracted data
         documentos_timbrados = []
 
-        # Extract the table rows
-        table_rows = data.xpath("//table[@class='tabla']/tr")
+        # Extract the table rows. Anchor to the "Documentos Timbrados" table
+        # specifically: the page has several class="tabla" tables, and the
+        # previous "//table[@class='tabla']/tr" mixed rows from all of them, so
+        # the date ranges of the "non-electronic authorization" table leaked in
+        # as bogus documents (e.g. {"Documento": "01-02-2017", ...}).
+        timbrados = data.xpath(
+            "//strong[contains(text(),'Documentos Timbrados')]"
+            "/following::table[@class='tabla'][1]"
+        )
+        table_rows = timbrados[0].xpath("./tr") if timbrados else []
 
         # Skip the header row (first row)
         for row in table_rows[1:]:


### PR DESCRIPTION
## Problema

La página del SII tiene varias tablas `class="tabla"`. El selector
`//table[@class='tabla']/tr` junta las filas de **todas**, así que las filas de
fechas de la tabla de "autorización a emitir en formato no electrónico" (que
también tienen 2 celdas) se cuelan como documentos timbrados.

Se ve en el propio ejemplo del README actual:

```json
{ "Documento": "01-02-2017", "Año último timbraje": "28-02-2017" }
```

Eso no es un documento timbrado: son las fechas Desde/Hasta de otra sección.

## Fix

Anclar la extracción a la tabla que sigue al
`<strong>Documentos Timbrados:</strong>`, en vez de a cualquier `class="tabla"`.
Cambio mínimo y localizado; no toca el resto del parseo.

## Verificación

Probado contra una respuesta real del SII: 8 documentos timbrados correctos,
0 filas de fecha coladas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
